### PR TITLE
Provide config for one card instead of list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ This custom card is valid in Sweden. It depends on the skolmat custom component 
 2. Install this card with HACS, or manually put skolmat-card.js in your www folder and add as resource.
 3. Add the card to lovelace config:
 ```
-  - type: custom:skolmat-card
-    entity: skolmat.skutehagen
-    menu_type: today # [today or week]
-    header: full # [full, short or none]
-    header_font: https://fonts.googleapis.com/css2?family=Inspiration&display=swap
-    header_fontsize: 2em
+type: custom:skolmat-card
+entity: skolmat.skutehagen
+menu_type: today # [today or week]
+header: full # [full, short or none]
+header_font: https://fonts.googleapis.com/css2?family=Inspiration&display=swap
+header_fontsize: 2em
 ```
 ## Lovelace configuration options
 


### PR DESCRIPTION
The provided config is not a config for a card but for a list of one card.

It's better to skip the `-` in these modern days of GUI configuration.